### PR TITLE
Add Sample Applet to All Accounts

### DIFF
--- a/app/applets/demoApplet.json
+++ b/app/applets/demoApplet.json
@@ -1,0 +1,5691 @@
+{
+    "activities": {
+        "reprolib:activities/MindLoggerDemo/MindLoggerDemo_schema": {
+            "@id": "reprolib:activities/MindLoggerDemo/MindLoggerDemo_schema",
+            "@type": [
+                "reprolib:schemas/Activity"
+            ],
+            "_id": "activity/5ea7175d86d25a5dbb14ea2a",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "This activity contains one of each type of widget supported by the MindLogger mobile app."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/MindLoggerDemo_schema",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "MindLogger Widget Demo"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "MindLogger Widget Demo"
+                }
+            ],
+            "reprolib:terms/allow": [
+                {
+                    "@list": [
+                        {
+                            "@id": "reprolib:terms/refused_to_answer"
+                        },
+                        {
+                            "@id": "reprolib:terms/dont_know_answer"
+                        }
+                    ]
+                }
+            ],
+            "reprolib:terms/order": [
+                {
+                    "@list": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/markdown-message"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/radio"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/radio-multi"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/slider"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/text"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/date"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/time-range"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/table-counter"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/table-text"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/audio-stimulus"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/audio-record"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/audio-image-record"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/drawing"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/drawing-image"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/photo"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/video"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/geolocation"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/vsr-instructions"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/visual-stimulus-response"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/delay"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/timer"
+                        },
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/upload"
+                        }
+                    ]
+                }
+            ],
+            "reprolib:terms/preamble": [
+                {
+                    "@language": "en",
+                    "@value": "Please follow the instructions for the task."
+                }
+            ],
+            "reprolib:terms/variableMap": [
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/markdown-message"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "markdown-message"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/radio"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "radio"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/radio-multi"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "radio-multi"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/slider"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "slider"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/text"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "text"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/date"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "date"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/time-range"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "time-range"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/table-counter"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "table-counter"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/table-text"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "table-text"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/audio-stimulus"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "audio-stimulus"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/audio-record"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "audio-record"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/audio-image-record"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "audio-image-record"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/drawing"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "drawing"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/drawing-image"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "drawing-image"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/photo"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "photo"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/video"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "video"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/vsr-instructions"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "vsr-instructions"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/visual-stimulus-response"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "visual-stimulus-response"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/delay"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "delay"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/timer"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "timer"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/geolocation"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "geolocation"
+                        }
+                    ]
+                },
+                {
+                    "reprolib:terms/isAbout": [
+                        {
+                            "@id": "reprolib:activities/MindLoggerDemo/items/upload"
+                        }
+                    ],
+                    "reprolib:terms/variableName": [
+                        {
+                            "@language": "en",
+                            "@value": "upload"
+                        }
+                    ]
+                }
+            ],
+            "reprolib:terms/visibility": [
+                {
+                    "@index": "audio-image-record",
+                    "@value": true
+                },
+                {
+                    "@index": "audio-record",
+                    "@value": true
+                },
+                {
+                    "@index": "audio-stimulus",
+                    "@value": true
+                },
+                {
+                    "@index": "date",
+                    "@value": true
+                },
+                {
+                    "@index": "delay",
+                    "@value": true
+                },
+                {
+                    "@index": "drawing",
+                    "@value": true
+                },
+                {
+                    "@index": "drawing-image",
+                    "@value": true
+                },
+                {
+                    "@index": "geolocation",
+                    "@value": true
+                },
+                {
+                    "@index": "markdown-message",
+                    "@value": true
+                },
+                {
+                    "@index": "photo",
+                    "@value": true
+                },
+                {
+                    "@index": "radio",
+                    "@value": true
+                },
+                {
+                    "@index": "radio-multi",
+                    "@value": true
+                },
+                {
+                    "@index": "slider",
+                    "@value": true
+                },
+                {
+                    "@index": "table-counter",
+                    "@value": true
+                },
+                {
+                    "@index": "table-text",
+                    "@value": true
+                },
+                {
+                    "@index": "text",
+                    "@value": true
+                },
+                {
+                    "@index": "time-range",
+                    "@value": true
+                },
+                {
+                    "@index": "timer",
+                    "@value": true
+                },
+                {
+                    "@index": "upload",
+                    "@value": true
+                },
+                {
+                    "@index": "video",
+                    "@value": true
+                },
+                {
+                    "@index": "visual-stimulus-response",
+                    "@value": true
+                },
+                {
+                    "@index": "vsr-instructions",
+                    "@value": true
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "This activity contains one of each type of widget supported by the MindLogger mobile app."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/MindLoggerDemo_schema",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/MindLoggerDemo_schema"
+        }
+    },
+    "applet": {
+        "@id": "reprolib:protocols/mindlogger-demo/mindlogger-demo_schema",
+        "_id": "applet/1",
+        "http://schema.org/about": [
+            {
+                "@language": "en",
+                "@value": "https://raw.githubusercontent.com/ReproNim/reproschema/master/protocols/mindlogger-demo/README.md"
+            }
+        ],
+        "http://schema.org/description": [
+            {
+                "@language": "en",
+                "@value": "Answer some questions about covid-19"
+            }
+        ],
+        "http://schema.org/image": "https://www.montgomery.edu/images/blogimages/covid-19_graphic.jpg",
+        "http://schema.org/schemaVersion": [
+            {
+                "@language": "en",
+                "@value": "0.0.1"
+            }
+        ],
+        "http://schema.org/version": [
+            {
+                "@language": "en",
+                "@value": "0.0.1"
+            }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+            {
+                "@language": "en",
+                "@value": "Covid-19 Applet"
+            }
+        ],
+        "reprolib:terms/order": [
+            {
+                "@list": [
+                    {
+                        "@id": "reprolib:activities/MindLoggerDemo/MindLoggerDemo_schema"
+                    }
+                ]
+            }
+        ],
+        "reprolib:terms/shuffle": [
+            {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+            }
+        ],
+        "responseDates": [],
+        "schema:about": [
+            {
+                "@language": "en",
+                "@value": "https://raw.githubusercontent.com/ReproNim/reproschema/master/protocols/mindlogger-demo/README.md"
+            }
+        ],
+        "schema:description": [
+            {
+                "@language": "en",
+                "@value": "Participate in a selection of demo activities to showcase the features of MindLogger."
+            }
+        ],
+        "schema:image": "https://raw.githubusercontent.com/ReproNim/reproschema/master/protocols/mindlogger-demo/mindlogger-logo.png",
+        "schema:schemaVersion": [
+            {
+                "@language": "en",
+                "@value": "0.0.1"
+            }
+        ],
+        "schema:version": [
+            {
+                "@language": "en",
+                "@value": "0.0.1"
+            }
+        ],
+        "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/protocols/mindlogger-demo/mindlogger-demo_schema"
+    },
+    "items": {
+        "reprolib:activities/MindLoggerDemo/items/audio-image-record": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/audio-image-record",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176186d25a5dbb14ea4e",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Audio Image widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Audio Image Record\r\n\r\nRecord audio from the user's microphone while showing the user a visual stimulus.\r\n\r\nLook at the map in the image below, and give directions to another person over the phone as to how you would follow the route from Start to Stop, using the landmarks."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/audio-image-record",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Audio Image Record"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Audio Image Record"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "audioImageRecord"
+                }
+            ],
+            "reprolib:terms/media": [
+                {
+                    "https://www.dropbox.com/s/wgtjq3bgqlfhbzd/map3g.png?raw=1": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://www.dropbox.com/s/wgtjq3bgqlfhbzd/map3g.png?raw=1",
+                            "http://schema.org/encodingFormat": "image/png",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Map"
+                                }
+                            ],
+                            "schema:contentUrl": "https://www.dropbox.com/s/wgtjq3bgqlfhbzd/map3g.png?raw=1",
+                            "schema:encodingFormat": "image/png",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Map"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "reprolib:terms/valueconstraints": [
+                {
+                    "http://schema.org/image": "https://www.dropbox.com/s/wgtjq3bgqlfhbzd/map3g.png?raw=1",
+                    "http://schema.org/maxValue": [
+                        {
+                            "@value": 60000
+                        }
+                    ],
+                    "http://schema.org/minValue": [
+                        {
+                            "@value": 0
+                        }
+                    ],
+                    "reprolib:terms/multipleChoice": [
+                        {
+                            "@type": "http://schema.org/Boolean",
+                            "@value": false
+                        }
+                    ],
+                    "reprolib:terms/requiredValue": [
+                        {
+                            "@type": "http://schema.org/Boolean",
+                            "@value": true
+                        }
+                    ],
+                    "schema:image": "https://www.dropbox.com/s/wgtjq3bgqlfhbzd/map3g.png?raw=1",
+                    "schema:maxValue": [
+                        {
+                            "@value": 60000
+                        }
+                    ],
+                    "schema:minValue": [
+                        {
+                            "@value": 0
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Audio Image widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Audio Image Record\r\n\r\nRecord audio from the user's microphone while showing the user a visual stimulus.\r\n\r\nLook at the map in the image below, and give directions to another person over the phone as to how you would follow the route from Start to Stop, using the landmarks."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/audio-image-record",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/audio-image-record"
+        },
+        "reprolib:activities/MindLoggerDemo/items/audio-record": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/audio-record",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176186d25a5dbb14ea4b",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Audio Record widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Audio Record\r\n\r\nRecord audio from the user's microphone. In this case we've configured the widget to have a maximum length of  10 seconds."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/audio-record",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Audio Record"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Audio Record"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "audioRecord"
+                }
+            ],
+            "reprolib:terms/valueconstraints": [
+                {
+                    "http://schema.org/maxValue": [
+                        {
+                            "@value": 10000
+                        }
+                    ],
+                    "http://schema.org/minValue": [
+                        {
+                            "@value": 0
+                        }
+                    ],
+                    "reprolib:terms/requiredValue": [
+                        {
+                            "@type": "http://schema.org/Boolean",
+                            "@value": true
+                        }
+                    ],
+                    "schema:maxValue": [
+                        {
+                            "@value": 10000
+                        }
+                    ],
+                    "schema:minValue": [
+                        {
+                            "@value": 0
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Audio Record widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Audio Record\r\n\r\nRecord audio from the user's microphone. In this case we've configured the widget to have a maximum length of  10 seconds."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/audio-record",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/audio-record"
+        },
+        "reprolib:activities/MindLoggerDemo/items/audio-stimulus": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/audio-stimulus",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176086d25a5dbb14ea48",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Audio Stimulus widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Audio Stimulus\r\n\r\nPlay a sound for the user.\r\n\r\nThis widget can be configured to play automatically when the user gets to this screen, and to advance to the following screen automatically.\r\n\r\nThis widget can also be configured to only play once."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/audio-stimulus",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "AudioStimulus"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "AudioStimulus"
+                }
+            ],
+            "reprolib:terms/allow": [
+                {
+                    "@list": [
+                        {
+                            "@id": "reprolib:terms/auto_advance"
+                        }
+                    ]
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "audioStimulus"
+                }
+            ],
+            "reprolib:terms/inputs": [
+                {
+                    "@type": [
+                        "http://schema.org/URL"
+                    ],
+                    "http://schema.org/contentUrl": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/ravlt-a.mp3",
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "stimulus"
+                        }
+                    ],
+                    "http://schema.org/value": [
+                        {
+                            "@language": "en",
+                            "@value": "reprolib:activities/MindLoggerDemo/items/ravlt-a.mp3"
+                        }
+                    ],
+                    "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/ravlt-a.mp3",
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "stimulus"
+                        }
+                    ],
+                    "schema:value": [
+                        {
+                            "@language": "en",
+                            "@value": "reprolib:activities/MindLoggerDemo/items/ravlt-a.mp3"
+                        }
+                    ]
+                },
+                {
+                    "@type": [
+                        "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "allowReplay"
+                        }
+                    ],
+                    "http://schema.org/value": [
+                        {
+                            "@value": true
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "allowReplay"
+                        }
+                    ],
+                    "schema:value": [
+                        {
+                            "@value": true
+                        }
+                    ]
+                }
+            ],
+            "reprolib:terms/media": [
+                {
+                    "reprolib:activities/MindLoggerDemo/items/ravlt-a.mp3": [
+                        {
+                            "@type": [
+                                "http://schema.org/AudioObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/ravlt-a.mp3",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "stimulus"
+                                }
+                            ],
+                            "http://schema.org/transcript": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+                                }
+                            ],
+                            "schema:contentUrl": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/ravlt-a.mp3",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "stimulus"
+                                }
+                            ],
+                            "schema:transcript": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Drum, Curtain, Bell, Coffee, School, Parent, Moon, Garden, Hat, Farmer, Nose, Turkey, Color, House, River."
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Audio Stimulus widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Audio Stimulus\r\n\r\nPlay a sound for the user.\r\n\r\nThis widget can be configured to play automatically when the user gets to this screen, and to advance to the following screen automatically.\r\n\r\nThis widget can also be configured to only play once."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/audio-stimulus",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/audio-stimulus"
+        },
+        "reprolib:activities/MindLoggerDemo/items/date": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/date",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7175f86d25a5dbb14ea3c",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Date widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Date\r\n\r\nThis widget uses the device's native date picker UI component.\r\n\r\nPlease select a date:"
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/date",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "date"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Date"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "date"
+                }
+            ],
+            "reprolib:terms/valueconstraints": [
+                {
+                    "http://schema.org/maxValue": [
+                        {
+                            "@language": "en",
+                            "@value": "new Date()"
+                        }
+                    ],
+                    "reprolib:terms/requiredValue": [
+                        {
+                            "@type": "http://schema.org/Boolean",
+                            "@value": true
+                        }
+                    ],
+                    "schema:maxValue": [
+                        {
+                            "@language": "en",
+                            "@value": "new Date()"
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Date widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Date\r\n\r\nThis widget uses the device's native date picker UI component.\r\n\r\nPlease select a date:"
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/date",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/date"
+        },
+        "reprolib:activities/MindLoggerDemo/items/delay": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/delay",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176486d25a5dbb14ea66",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Delay option"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Delay\r\n\r\nEach widget can be configured to have a delay period during which the user cannot answer. This has many potentioal uses such as getting the user to carefully read a question before answering.\r\n\r\nHow was your child's day?"
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/delay",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "delay"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Delay"
+                }
+            ],
+            "reprolib:terms/delay": [
+                {
+                    "@value": 5000
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "radio"
+                }
+            ],
+            "reprolib:terms/valueconstraints": [
+                {
+                    "@type": [
+                        "http://www.w3.org/2001/XMLSchema#anyURI"
+                    ],
+                    "http://schema.org/itemListElement": [
+                        {
+                            "@list": [
+                                {
+                                    "@type": [
+                                        "http://schema.org/Boolean"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44E.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Bad Day"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44E.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Bad Day"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/Boolean"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44D.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Good Day"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44D.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Good Day"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "http://schema.org/maxValue": [
+                        {
+                            "@value": 1
+                        }
+                    ],
+                    "http://schema.org/minValue": [
+                        {
+                            "@value": 0
+                        }
+                    ],
+                    "reprolib:terms/multipleChoice": [
+                        {
+                            "@type": "http://schema.org/Boolean",
+                            "@value": false
+                        }
+                    ],
+                    "schema:itemListElement": [
+                        {
+                            "@list": [
+                                {
+                                    "@type": [
+                                        "http://schema.org/Boolean"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44E.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Bad Day"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44E.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Bad Day"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/Boolean"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44D.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Good Day"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44D.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Good Day"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "schema:maxValue": [
+                        {
+                            "@value": 1
+                        }
+                    ],
+                    "schema:minValue": [
+                        {
+                            "@value": 0
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Delay option"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Delay\r\n\r\nEach widget can be configured to have a delay period during which the user cannot answer. This has many potentioal uses such as getting the user to carefully read a question before answering.\r\n\r\nHow was your child's day?"
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/delay",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/delay"
+        },
+        "reprolib:activities/MindLoggerDemo/items/drawing": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/drawing",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176186d25a5dbb14ea51",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Drawing widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Drawing\r\n\r\nThis widget allows the user to draw a picture on the screen using their finger or cursor."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/drawing",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "drawing"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Drawing"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "drawing"
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Drawing widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Drawing\r\n\r\nThis widget allows the user to draw a picture on the screen using their finger or cursor."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/drawing",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/drawing"
+        },
+        "reprolib:activities/MindLoggerDemo/items/drawing-image": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/drawing-image",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176286d25a5dbb14ea54",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Drawing widget with an image"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Drawing (with image)\r\n\r\nThe Drawing widget can optionally have an image in the background that the user draws on top of."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/drawing-image",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "drawing-image"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Drawing with image"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "drawing"
+                }
+            ],
+            "reprolib:terms/inputs": [
+                {
+                    "@type": [
+                        "http://schema.org/URL"
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "backgroundImage"
+                        }
+                    ],
+                    "http://schema.org/value": [
+                        {
+                            "@language": "en",
+                            "@value": "https://image.freepik.com/free-vector/abstract-geometric-pattern-background_1319-242.jpg"
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "backgroundImage"
+                        }
+                    ],
+                    "schema:value": [
+                        {
+                            "@language": "en",
+                            "@value": "https://image.freepik.com/free-vector/abstract-geometric-pattern-background_1319-242.jpg"
+                        }
+                    ]
+                }
+            ],
+            "reprolib:terms/media": [
+                {
+                    "https://image.freepik.com/free-vector/abstract-geometric-pattern-background_1319-242.jpg": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://image.freepik.com/free-vector/abstract-geometric-pattern-background_1319-242.jpg",
+                            "http://schema.org/encodingFormat": "image/jpeg",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Abstract Pattern"
+                                }
+                            ],
+                            "schema:contentUrl": "https://image.freepik.com/free-vector/abstract-geometric-pattern-background_1319-242.jpg",
+                            "schema:encodingFormat": "image/jpeg",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Abstract Pattern"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Drawing widget with an image"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Drawing (with image)\r\n\r\nThe Drawing widget can optionally have an image in the background that the user draws on top of."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/drawing-image",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/drawing-image"
+        },
+        "reprolib:activities/MindLoggerDemo/items/geolocation": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/geolocation",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176386d25a5dbb14ea5d",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Geolocation widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Geolocation\r\n\r\nRecord the user's latitude and longitude using their device location. The user will be prompted to grant access to their location when they click the button."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/geolocation",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Geolocation"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Geolocation"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "geolocation"
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Geolocation widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Geolocation\r\n\r\nRecord the user's latitude and longitude using their device location. The user will be prompted to grant access to their location when they click the button."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/geolocation",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/geolocation"
+        },
+        "reprolib:activities/MindLoggerDemo/items/markdown-message": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/markdown-message",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7175d86d25a5dbb14ea2d",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Markdown Message widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Markdown Message\r\n\r\nThe Markdown Message widget allows you to write an instruction page using the popular [Markdown](https://en.wikipedia.org/wiki/Markdown) language.\r\n\r\nThis allows you to display formatted text, hyperlinks, and even images!\r\n\r\n![sparkle emoji](https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/160/apple/198/sparkles_2728.png =64x64)\r\n\r\nNote that unlike other widgets, the user can always go to the \"Next\" screen after a Markdown Message screen."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/markdown-message",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "markdown-message"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Markdown Message"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "markdown-message"
+                }
+            ],
+            "reprolib:terms/media": [
+                {
+                    "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/160/apple/198/sparkles_2728.png": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/160/apple/198/sparkles_2728.png",
+                            "http://schema.org/encodingFormat": "image/jpeg",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Sparkle Emoji"
+                                }
+                            ],
+                            "schema:contentUrl": "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/160/apple/198/sparkles_2728.png",
+                            "schema:encodingFormat": "image/jpeg",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Sparkle Emoji"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Markdown Message widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Markdown Message\r\n\r\nThe Markdown Message widget allows you to write an instruction page using the popular [Markdown](https://en.wikipedia.org/wiki/Markdown) language.\r\n\r\nThis allows you to display formatted text, hyperlinks, and even images!\r\n\r\n![sparkle emoji](https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/160/apple/198/sparkles_2728.png =64x64)\r\n\r\nNote that unlike other widgets, the user can always go to the \"Next\" screen after a Markdown Message screen."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/markdown-message",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/markdown-message"
+        },
+        "reprolib:activities/MindLoggerDemo/items/photo": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/photo",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176286d25a5dbb14ea57",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Photo widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Photo\r\n\r\nTake a photo or upload a photo from the user's camera roll."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/photo",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Photo"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Photo"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "photo"
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Photo widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Photo\r\n\r\nTake a photo or upload a photo from the user's camera roll."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/photo",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/photo"
+        },
+        "reprolib:activities/MindLoggerDemo/items/radio": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/radio",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7175d86d25a5dbb14ea30",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Radio widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Radio\r\n\r\nThe Radio widget allows the user to respond to a multiple choice question. Options can also have images associated with them.\r\n\r\nHow was your child's day?"
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/radio",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "radio"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Radio"
+                }
+            ],
+            "reprolib:terms/allow": [
+                {
+                    "@list": [
+                        {
+                            "@id": "reprolib:terms/auto_advance"
+                        }
+                    ]
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "radio"
+                }
+            ],
+            "reprolib:terms/media": [
+                {
+                    "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44D.jpg": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44D.jpg",
+                            "http://schema.org/encodingFormat": "image/jpeg",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Smiling Emoji"
+                                }
+                            ],
+                            "schema:contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44D.jpg",
+                            "schema:encodingFormat": "image/jpeg",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Smiling Emoji"
+                                }
+                            ]
+                        }
+                    ],
+                    "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44E.jpg": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44E.jpg",
+                            "http://schema.org/encodingFormat": "image/jpeg",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Upset Emoji"
+                                }
+                            ],
+                            "schema:contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44E.jpg",
+                            "schema:encodingFormat": "image/jpeg",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Upset Emoji"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "reprolib:terms/valueconstraints": [
+                {
+                    "@type": [
+                        "http://www.w3.org/2001/XMLSchema#anyURI"
+                    ],
+                    "http://schema.org/itemListElement": [
+                        {
+                            "@list": [
+                                {
+                                    "@type": [
+                                        "http://schema.org/Boolean"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44E.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Bad Day"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44E.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Bad Day"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/Boolean"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44D.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Good Day"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44D.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Good Day"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "http://schema.org/maxValue": [
+                        {
+                            "@value": 1
+                        }
+                    ],
+                    "http://schema.org/minValue": [
+                        {
+                            "@value": 0
+                        }
+                    ],
+                    "reprolib:terms/multipleChoice": [
+                        {
+                            "@type": "http://schema.org/Boolean",
+                            "@value": false
+                        }
+                    ],
+                    "schema:itemListElement": [
+                        {
+                            "@list": [
+                                {
+                                    "@type": [
+                                        "http://schema.org/Boolean"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44E.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Bad Day"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44E.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Bad Day"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/Boolean"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44D.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Good Day"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F44D.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Good Day"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "schema:maxValue": [
+                        {
+                            "@value": 1
+                        }
+                    ],
+                    "schema:minValue": [
+                        {
+                            "@value": 0
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Radio widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Radio\r\n\r\nThe Radio widget allows the user to respond to a multiple choice question. Options can also have images associated with them.\r\n\r\nHow was your child's day?"
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/radio",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/radio"
+        },
+        "reprolib:activities/MindLoggerDemo/items/radio-multi": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/radio-multi",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7175e86d25a5dbb14ea33",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of a multiple choice Radio widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Radio (multi-select)\r\n\r\nThe radio widget can also be configured to allow multiple responses.\r\n\r\nWhat were some sources of stress?"
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/radio-multi",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "radio-multi"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Radio (multi-select)"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "radio"
+                }
+            ],
+            "reprolib:terms/media": [
+                {
+                    "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F469-200D-1F3EB.jpg": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F469-200D-1F3EB.jpg",
+                            "http://schema.org/encodingFormat": "image/jpeg",
+                            "schema:contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F469-200D-1F3EB.jpg",
+                            "schema:encodingFormat": "image/jpeg"
+                        }
+                    ],
+                    "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F47F.jpg": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F47F.jpg",
+                            "http://schema.org/encodingFormat": "image/jpeg",
+                            "schema:contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F47F.jpg",
+                            "schema:encodingFormat": "image/jpeg"
+                        }
+                    ],
+                    "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F4DD.jpg": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F4DD.jpg",
+                            "http://schema.org/encodingFormat": "image/jpeg",
+                            "schema:contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F4DD.jpg",
+                            "schema:encodingFormat": "image/jpeg"
+                        }
+                    ],
+                    "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F915.jpg": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F915.jpg",
+                            "http://schema.org/encodingFormat": "image/jpeg",
+                            "schema:contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F915.jpg",
+                            "schema:encodingFormat": "image/jpeg"
+                        }
+                    ],
+                    "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/2764.jpg": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/2764.jpg",
+                            "http://schema.org/encodingFormat": "image/jpeg",
+                            "schema:contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/2764.jpg",
+                            "schema:encodingFormat": "image/jpeg"
+                        }
+                    ],
+                    "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/E246.jpg": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/E246.jpg",
+                            "http://schema.org/encodingFormat": "image/jpeg",
+                            "schema:contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/E246.jpg",
+                            "schema:encodingFormat": "image/jpeg"
+                        }
+                    ]
+                }
+            ],
+            "reprolib:terms/valueconstraints": [
+                {
+                    "@type": [
+                        "http://www.w3.org/2001/XMLSchema#anyURI"
+                    ],
+                    "http://schema.org/itemListElement": [
+                        {
+                            "@list": [
+                                {
+                                    "@type": [
+                                        "http://schema.org/option"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F915.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Didn't feel well"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F915.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Didn't feel well"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/option"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F469-200D-1F3EB.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Classroom learning"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F469-200D-1F3EB.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Classroom learning"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/option"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F4DD.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "A test or quiz at school"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 2
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F4DD.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "A test or quiz at school"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 2
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/option"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F47F.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Bullying"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 3
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F47F.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Bullying"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 3
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/option"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/E246.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Online relationships"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 4
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/E246.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Online relationships"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 4
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/option"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/2764.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Death of a loved one"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 5
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/2764.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Death of a loved one"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 5
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "http://schema.org/maxValue": [
+                        {
+                            "@value": 2
+                        }
+                    ],
+                    "http://schema.org/minValue": [
+                        {
+                            "@value": 0
+                        }
+                    ],
+                    "reprolib:terms/multipleChoice": [
+                        {
+                            "@type": "http://schema.org/Boolean",
+                            "@value": true
+                        }
+                    ],
+                    "schema:itemListElement": [
+                        {
+                            "@list": [
+                                {
+                                    "@type": [
+                                        "http://schema.org/option"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F915.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Didn't feel well"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F915.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Didn't feel well"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/option"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F469-200D-1F3EB.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Classroom learning"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F469-200D-1F3EB.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Classroom learning"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/option"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F4DD.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "A test or quiz at school"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 2
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F4DD.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "A test or quiz at school"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 2
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/option"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F47F.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Bullying"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 3
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F47F.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Bullying"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 3
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/option"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/E246.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Online relationships"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 4
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/E246.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Online relationships"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 4
+                                        }
+                                    ]
+                                },
+                                {
+                                    "@type": [
+                                        "http://schema.org/option"
+                                    ],
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/2764.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Death of a loved one"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 5
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/2764.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "Death of a loved one"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 5
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "schema:maxValue": [
+                        {
+                            "@value": 2
+                        }
+                    ],
+                    "schema:minValue": [
+                        {
+                            "@value": 0
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of a multiple choice Radio widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Radio (multi-select)\r\n\r\nThe radio widget can also be configured to allow multiple responses.\r\n\r\nWhat were some sources of stress?"
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/radio-multi",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/radio-multi"
+        },
+        "reprolib:activities/MindLoggerDemo/items/slider": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/slider",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7175e86d25a5dbb14ea36",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Slider widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Slider\r\n\r\nThe Slider widget allows the user to drag their finger to a specific value.\r\n\r\nHow much did your child enjoy the day?"
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/slider",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "slider"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Slider"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "slider"
+                }
+            ],
+            "reprolib:terms/media": [
+                {
+                    "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F601.jpg": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F601.jpg",
+                            "http://schema.org/encodingFormat": "image/jpeg",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Happy Emoji"
+                                }
+                            ],
+                            "schema:contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F601.jpg",
+                            "schema:encodingFormat": "image/jpeg",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Happy Emoji"
+                                }
+                            ]
+                        }
+                    ],
+                    "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F621.jpg": [
+                        {
+                            "@type": [
+                                "http://schema.org/ImageObject"
+                            ],
+                            "http://schema.org/contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F621.jpg",
+                            "http://schema.org/encodingFormat": "image/jpeg",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Frowning Emoji"
+                                }
+                            ],
+                            "schema:contentUrl": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F621.jpg",
+                            "schema:encodingFormat": "image/jpeg",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Frowning Emoji"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "reprolib:terms/valueconstraints": [
+                {
+                    "@type": [
+                        "http://www.w3.org/2001/XMLSchema#integer"
+                    ],
+                    "http://schema.org/itemListElement": [
+                        {
+                            "@list": [
+                                {
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F621.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "0"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F621.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "0"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ]
+                                },
+                                {
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "1"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ],
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "1"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "2"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 2
+                                        }
+                                    ],
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "2"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 2
+                                        }
+                                    ]
+                                },
+                                {
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "3"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 3
+                                        }
+                                    ],
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "3"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 3
+                                        }
+                                    ]
+                                },
+                                {
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "4"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 4
+                                        }
+                                    ],
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "4"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 4
+                                        }
+                                    ]
+                                },
+                                {
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F601.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "5"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 5
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F601.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "5"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 5
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "http://schema.org/maxValue": [
+                        {
+                            "@language": "en",
+                            "@value": "Really enjoying things"
+                        }
+                    ],
+                    "http://schema.org/minValue": [
+                        {
+                            "@language": "en",
+                            "@value": "No enjoyment or pleasure"
+                        }
+                    ],
+                    "reprolib:terms/requiredValue": [
+                        {
+                            "@type": "http://schema.org/Boolean",
+                            "@value": false
+                        }
+                    ],
+                    "schema:itemListElement": [
+                        {
+                            "@list": [
+                                {
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F621.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "0"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F621.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "0"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 0
+                                        }
+                                    ]
+                                },
+                                {
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "1"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ],
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "1"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 1
+                                        }
+                                    ]
+                                },
+                                {
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "2"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 2
+                                        }
+                                    ],
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "2"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 2
+                                        }
+                                    ]
+                                },
+                                {
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "3"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 3
+                                        }
+                                    ],
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "3"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 3
+                                        }
+                                    ]
+                                },
+                                {
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "4"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 4
+                                        }
+                                    ],
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "4"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 4
+                                        }
+                                    ]
+                                },
+                                {
+                                    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F601.jpg",
+                                    "http://schema.org/name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "5"
+                                        }
+                                    ],
+                                    "http://schema.org/value": [
+                                        {
+                                            "@value": 5
+                                        }
+                                    ],
+                                    "schema:image": "https://childmindinstitute.github.io/mindlogger-assets/emojis/openmoji/1F601.jpg",
+                                    "schema:name": [
+                                        {
+                                            "@language": "en",
+                                            "@value": "5"
+                                        }
+                                    ],
+                                    "schema:value": [
+                                        {
+                                            "@value": 5
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "schema:maxValue": [
+                        {
+                            "@language": "en",
+                            "@value": "Really enjoying things"
+                        }
+                    ],
+                    "schema:minValue": [
+                        {
+                            "@language": "en",
+                            "@value": "No enjoyment or pleasure"
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Slider widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Slider\r\n\r\nThe Slider widget allows the user to drag their finger to a specific value.\r\n\r\nHow much did your child enjoy the day?"
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/slider",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/slider"
+        },
+        "reprolib:activities/MindLoggerDemo/items/table-counter": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/table-counter",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176086d25a5dbb14ea42",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Table Counter widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Table Counter\r\n\r\nThe editor defines the number of rows and columns and the labels. Each table cell is a counter that the user can increment by pressing on it. The user can decrement the counter by doing a long press.\r\n\r\nIn this example, a list of names appears along the x-axis together with some behaviors along the y-axis."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/table-counter",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Table Counter"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Table Counter"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "tableCounter"
+                }
+            ],
+            "reprolib:terms/inputs": [
+                {
+                    "@type": [
+                        "http://schema.org/ItemList"
+                    ],
+                    "http://schema.org/itemListElement": [
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Daniel"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Daniel"
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Jessica"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Jessica"
+                                }
+                            ]
+                        }
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "cols"
+                        }
+                    ],
+                    "http://schema.org/numberOfItems": [
+                        {
+                            "@value": 2
+                        }
+                    ],
+                    "schema:itemListElement": [
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Daniel"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Daniel"
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Jessica"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Jessica"
+                                }
+                            ]
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "cols"
+                        }
+                    ],
+                    "schema:numberOfItems": [
+                        {
+                            "@value": 2
+                        }
+                    ]
+                },
+                {
+                    "@type": [
+                        "http://schema.org/ItemList"
+                    ],
+                    "http://schema.org/itemListElement": [
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Biting"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Biting"
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Yelling"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Yelling"
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Hitting"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Hitting"
+                                }
+                            ]
+                        }
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "rows"
+                        }
+                    ],
+                    "http://schema.org/numberOfItems": [
+                        {
+                            "@value": 3
+                        }
+                    ],
+                    "schema:itemListElement": [
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Biting"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Biting"
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Yelling"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Yelling"
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Hitting"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Hitting"
+                                }
+                            ]
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "rows"
+                        }
+                    ],
+                    "schema:numberOfItems": [
+                        {
+                            "@value": 3
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Table Counter widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Table Counter\r\n\r\nThe editor defines the number of rows and columns and the labels. Each table cell is a counter that the user can increment by pressing on it. The user can decrement the counter by doing a long press.\r\n\r\nIn this example, a list of names appears along the x-axis together with some behaviors along the y-axis."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/table-counter",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/table-counter"
+        },
+        "reprolib:activities/MindLoggerDemo/items/table-text": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/table-test",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176086d25a5dbb14ea45",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Table Text widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Table Text\r\n\r\nThe editor defines the number of rows and columns and the labels. Each table cell is a text entry field that the user can enter anything they want into.\r\n\r\nIn this example, a list of names appears along the x-axis together with some behaviors along the y-axis."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/table-text",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Table Text"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Table Text"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "tableText"
+                }
+            ],
+            "reprolib:terms/inputs": [
+                {
+                    "@type": [
+                        "http://schema.org/ItemList"
+                    ],
+                    "http://schema.org/itemListElement": [
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Daniel"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Daniel"
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Jessica"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Jessica"
+                                }
+                            ]
+                        }
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "cols"
+                        }
+                    ],
+                    "http://schema.org/numberOfItems": [
+                        {
+                            "@value": 2
+                        }
+                    ],
+                    "schema:itemListElement": [
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Daniel"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Daniel"
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Jessica"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Jessica"
+                                }
+                            ]
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "cols"
+                        }
+                    ],
+                    "schema:numberOfItems": [
+                        {
+                            "@value": 2
+                        }
+                    ]
+                },
+                {
+                    "@type": [
+                        "http://schema.org/ItemList"
+                    ],
+                    "http://schema.org/itemListElement": [
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Biting"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Biting"
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Yelling"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Yelling"
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Hitting"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Hitting"
+                                }
+                            ]
+                        }
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "rows"
+                        }
+                    ],
+                    "http://schema.org/numberOfItems": [
+                        {
+                            "@value": 3
+                        }
+                    ],
+                    "schema:itemListElement": [
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Biting"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Biting"
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Yelling"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Yelling"
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Text"
+                            ],
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Hitting"
+                                }
+                            ],
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "label"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@language": "en",
+                                    "@value": "Hitting"
+                                }
+                            ]
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "rows"
+                        }
+                    ],
+                    "schema:numberOfItems": [
+                        {
+                            "@value": 3
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Table Text widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Table Text\r\n\r\nThe editor defines the number of rows and columns and the labels. Each table cell is a text entry field that the user can enter anything they want into.\r\n\r\nIn this example, a list of names appears along the x-axis together with some behaviors along the y-axis."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/table-text",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/table-text"
+        },
+        "reprolib:activities/MindLoggerDemo/items/text": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/text",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7175e86d25a5dbb14ea39",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Text widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Text\r\n\r\nA simple one-line text-entry widget.\r\n\r\nPlease some text:"
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/text",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "test"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Text"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "text"
+                }
+            ],
+            "reprolib:terms/valueconstraints": [
+                {}
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Text widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Text\r\n\r\nA simple one-line text-entry widget.\r\n\r\nPlease some text:"
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/text",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/text"
+        },
+        "reprolib:activities/MindLoggerDemo/items/time-range": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/time-range",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7175f86d25a5dbb14ea3f",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Time Range widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Time Range\r\n\r\nThis widget uses the device's native time picker UI components.\r\n\r\nPlease select a time range:"
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/time-range",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "time-range"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Time Range"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "timeRange"
+                }
+            ],
+            "reprolib:terms/valueconstraints": [
+                {}
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Time Range widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Time Range\r\n\r\nThis widget uses the device's native time picker UI components.\r\n\r\nPlease select a time range:"
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/time-range",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/time-range"
+        },
+        "reprolib:activities/MindLoggerDemo/items/timer": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/timer",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176486d25a5dbb14ea69",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Timer option"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Timer\r\n\r\nEach widget can be configured to have a timer. When the timer elapses the app will advance to the next screen, either skipping the screen or using the current answer.\r\n\r\nDraw a smiley face in 30 seconds."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/timer",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "timer"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Timer"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "drawing"
+                }
+            ],
+            "reprolib:terms/timer": [
+                {
+                    "@value": 30000
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Timer option"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Timer\r\n\r\nEach widget can be configured to have a timer. When the timer elapses the app will advance to the next screen, either skipping the screen or using the current answer.\r\n\r\nDraw a smiley face in 30 seconds."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/timer",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/timer"
+        },
+        "reprolib:activities/MindLoggerDemo/items/upload": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/upload-message",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176586d25a5dbb14ea6c",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Upload message"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Upload\r\n\r\nThe MindLogger demo is complete. Press *Done* below to complete the activity and upload your responses to the backend, or press the close icon in the top right to leave the activity without uploading."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/upload",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Upload message"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Upload Message"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "markdown-message"
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Upload message"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Upload\r\n\r\nThe MindLogger demo is complete. Press *Done* below to complete the activity and upload your responses to the backend, or press the close icon in the top right to leave the activity without uploading."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/upload",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/upload"
+        },
+        "reprolib:activities/MindLoggerDemo/items/video": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/video",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176286d25a5dbb14ea5a",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Video widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Video\r\n\r\nTake a video or upload a video from the user's library."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/video",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Video"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Video"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "video"
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Demo of the Video widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Video\r\n\r\nTake a video or upload a video from the user's library."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/video",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/video"
+        },
+        "reprolib:activities/MindLoggerDemo/items/visual-stimulus-response": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/visual-stimulus-response",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176486d25a5dbb14ea63",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Flanker practice"
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/visual-stimulus-response",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Visual Stimulus Response"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Visual Stimulus Response"
+                }
+            ],
+            "reprolib:terms/allow": [
+                {
+                    "@list": [
+                        {
+                            "@id": "reprolib:terms/auto_advance"
+                        }
+                    ]
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "visual-stimulus-response"
+                }
+            ],
+            "reprolib:terms/inputs": [
+                {
+                    "@type": [
+                        "http://schema.org/ItemList"
+                    ],
+                    "http://schema.org/itemListElement": [
+                        {
+                            "@type": [
+                                "http://schema.org/Property"
+                            ],
+                            "http://schema.org/image": "<h3>A 2016 interview with this Batman actor found him looking sad; the internet then made him the meme we deserve</h3>",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "q1"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@value": 1
+                                }
+                            ],
+                            "reprolib:terms/valueconstraints": [
+                                {
+                                    "@type": [
+                                        "http://www.w3.org/2001/XMLSchema#anyURI"
+                                    ],
+                                    "http://schema.org/itemListElement": [
+                                        {
+                                            "@list": [
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Christian Bale"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Christian Bale"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Ben Affleck"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Ben Affleck"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "schema:itemListElement": [
+                                        {
+                                            "@list": [
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Christian Bale"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Christian Bale"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Ben Affleck"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Ben Affleck"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "schema:image": "<h3>A 2016 interview with this Batman actor found him looking sad; the internet then made him the meme we deserve</h3>",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "q1"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Property"
+                            ],
+                            "http://schema.org/image": "<h3>A common sight was walking around Monet who worked outdoors, as in a cliff walk in this Channel-side French region</h3",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "q2"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@value": 0
+                                }
+                            ],
+                            "reprolib:terms/valueconstraints": [
+                                {
+                                    "@type": [
+                                        "http://www.w3.org/2001/XMLSchema#anyURI"
+                                    ],
+                                    "http://schema.org/itemListElement": [
+                                        {
+                                            "@list": [
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Normandy"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Normandy"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Brittany"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Brittany"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "schema:itemListElement": [
+                                        {
+                                            "@list": [
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Normandy"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Normandy"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Brittany"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Brittany"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "schema:image": "<h3>A common sight was walking around Monet who worked outdoors, as in a cliff walk in this Channel-side French region</h3",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "q2"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Property"
+                            ],
+                            "http://schema.org/image": "<h3>Modern auto safety took a big step in '66 as LBJ signed bills mandating seatbelts & rupture-resistant these</h3>",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "q3"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@value": 1
+                                }
+                            ],
+                            "reprolib:terms/valueconstraints": [
+                                {
+                                    "@type": [
+                                        "http://www.w3.org/2001/XMLSchema#anyURI"
+                                    ],
+                                    "http://schema.org/itemListElement": [
+                                        {
+                                            "@list": [
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Air bags"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Air bags"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Fuel tanks"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Fuel tanks"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "schema:itemListElement": [
+                                        {
+                                            "@list": [
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Air bags"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Air bags"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Fuel tanks"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Fuel tanks"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "schema:image": "<h3>Modern auto safety took a big step in '66 as LBJ signed bills mandating seatbelts & rupture-resistant these</h3>",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "q3"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@value": 1
+                                }
+                            ]
+                        }
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "trials"
+                        }
+                    ],
+                    "http://schema.org/numberOfItems": [
+                        {
+                            "@value": 3
+                        }
+                    ],
+                    "schema:itemListElement": [
+                        {
+                            "@type": [
+                                "http://schema.org/Property"
+                            ],
+                            "http://schema.org/image": "<h3>A 2016 interview with this Batman actor found him looking sad; the internet then made him the meme we deserve</h3>",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "q1"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@value": 1
+                                }
+                            ],
+                            "reprolib:terms/valueconstraints": [
+                                {
+                                    "@type": [
+                                        "http://www.w3.org/2001/XMLSchema#anyURI"
+                                    ],
+                                    "http://schema.org/itemListElement": [
+                                        {
+                                            "@list": [
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Christian Bale"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Christian Bale"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Ben Affleck"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Ben Affleck"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "schema:itemListElement": [
+                                        {
+                                            "@list": [
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Christian Bale"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Christian Bale"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Ben Affleck"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Ben Affleck"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "schema:image": "<h3>A 2016 interview with this Batman actor found him looking sad; the internet then made him the meme we deserve</h3>",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "q1"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@value": 1
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Property"
+                            ],
+                            "http://schema.org/image": "<h3>A common sight was walking around Monet who worked outdoors, as in a cliff walk in this Channel-side French region</h3",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "q2"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@value": 0
+                                }
+                            ],
+                            "reprolib:terms/valueconstraints": [
+                                {
+                                    "@type": [
+                                        "http://www.w3.org/2001/XMLSchema#anyURI"
+                                    ],
+                                    "http://schema.org/itemListElement": [
+                                        {
+                                            "@list": [
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Normandy"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Normandy"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Brittany"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Brittany"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "schema:itemListElement": [
+                                        {
+                                            "@list": [
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Normandy"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Normandy"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Brittany"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Brittany"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "schema:image": "<h3>A common sight was walking around Monet who worked outdoors, as in a cliff walk in this Channel-side French region</h3",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "q2"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@value": 0
+                                }
+                            ]
+                        },
+                        {
+                            "@type": [
+                                "http://schema.org/Property"
+                            ],
+                            "http://schema.org/image": "<h3>Modern auto safety took a big step in '66 as LBJ signed bills mandating seatbelts & rupture-resistant these</h3>",
+                            "http://schema.org/name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "q3"
+                                }
+                            ],
+                            "http://schema.org/value": [
+                                {
+                                    "@value": 1
+                                }
+                            ],
+                            "reprolib:terms/valueconstraints": [
+                                {
+                                    "@type": [
+                                        "http://www.w3.org/2001/XMLSchema#anyURI"
+                                    ],
+                                    "http://schema.org/itemListElement": [
+                                        {
+                                            "@list": [
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Air bags"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Air bags"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Fuel tanks"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Fuel tanks"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "schema:itemListElement": [
+                                        {
+                                            "@list": [
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Air bags"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Air bags"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 0
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "@type": [
+                                                        "http://schema.org/Number"
+                                                    ],
+                                                    "http://schema.org/name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Fuel tanks"
+                                                        }
+                                                    ],
+                                                    "http://schema.org/value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ],
+                                                    "schema:name": [
+                                                        {
+                                                            "@language": "en",
+                                                            "@value": "Fuel tanks"
+                                                        }
+                                                    ],
+                                                    "schema:value": [
+                                                        {
+                                                            "@value": 1
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "schema:image": "<h3>Modern auto safety took a big step in '66 as LBJ signed bills mandating seatbelts & rupture-resistant these</h3>",
+                            "schema:name": [
+                                {
+                                    "@language": "en",
+                                    "@value": "q3"
+                                }
+                            ],
+                            "schema:value": [
+                                {
+                                    "@value": 1
+                                }
+                            ]
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "trials"
+                        }
+                    ],
+                    "schema:numberOfItems": [
+                        {
+                            "@value": 3
+                        }
+                    ]
+                },
+                {
+                    "@type": [
+                        "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "showFixation"
+                        }
+                    ],
+                    "http://schema.org/value": [
+                        {
+                            "@value": false
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "showFixation"
+                        }
+                    ],
+                    "schema:value": [
+                        {
+                            "@value": false
+                        }
+                    ]
+                },
+                {
+                    "@type": [
+                        "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "showFeedback"
+                        }
+                    ],
+                    "http://schema.org/value": [
+                        {
+                            "@value": true
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "showFeedback"
+                        }
+                    ],
+                    "schema:value": [
+                        {
+                            "@value": true
+                        }
+                    ]
+                },
+                {
+                    "@type": [
+                        "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "showResults"
+                        }
+                    ],
+                    "http://schema.org/value": [
+                        {
+                            "@value": true
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "showResults"
+                        }
+                    ],
+                    "schema:value": [
+                        {
+                            "@value": true
+                        }
+                    ]
+                },
+                {
+                    "@type": [
+                        "http://schema.org/Text"
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "samplingMethod"
+                        }
+                    ],
+                    "http://schema.org/value": [
+                        {
+                            "@language": "en",
+                            "@value": "randomize-order"
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "samplingMethod"
+                        }
+                    ],
+                    "schema:value": [
+                        {
+                            "@language": "en",
+                            "@value": "randomize-order"
+                        }
+                    ]
+                },
+                {
+                    "@type": [
+                        "http://schema.org/Number"
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "sampleSize"
+                        }
+                    ],
+                    "http://schema.org/value": [
+                        {
+                            "@value": 3
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "sampleSize"
+                        }
+                    ],
+                    "schema:value": [
+                        {
+                            "@value": 3
+                        }
+                    ]
+                },
+                {
+                    "@type": [
+                        "http://schema.org/Number"
+                    ],
+                    "http://schema.org/name": [
+                        {
+                            "@language": "en",
+                            "@value": "trialDuration"
+                        }
+                    ],
+                    "http://schema.org/value": [
+                        {
+                            "@value": 10000
+                        }
+                    ],
+                    "schema:name": [
+                        {
+                            "@language": "en",
+                            "@value": "trialDuration"
+                        }
+                    ],
+                    "schema:value": [
+                        {
+                            "@value": 10000
+                        }
+                    ]
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Flanker practice"
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/visual-stimulus-response",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/visual-stimulus-response"
+        },
+        "reprolib:activities/MindLoggerDemo/items/vsr-instructions": {
+            "@id": "reprolib:activities/MindLoggerDemo/items/vsr-instructions",
+            "@type": [
+                "reprolib:schemas/Field"
+            ],
+            "_id": "screen/5ea7176386d25a5dbb14ea60",
+            "http://schema.org/description": [
+                {
+                    "@language": "en",
+                    "@value": "Instructions for the Visual Stimulus Response widget"
+                }
+            ],
+            "http://schema.org/question": [
+                {
+                    "@language": "en",
+                    "@value": "## Visual Stimulus Response\r\n\r\nThe following page is an example of the Visual Stimulus Response widget. This complex widget shows the user a certain number of trials. In each trial the user is presented with a visual stimulus in the center of the screen. The user must respond to the stimuli by pressing a button at the bottom of the screen.\r\n\r\nThis widget is highly configurable. You can configure the sampling method and sampling size, whether to show the user feedback, and much more.\r\n\r\nThe following page contains a little Jeopardy! quiz."
+                }
+            ],
+            "http://schema.org/schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/vsr-instructions",
+            "http://schema.org/version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#altLabel": [
+                {
+                    "@language": "en",
+                    "@value": "vsr-insructions"
+                }
+            ],
+            "http://www.w3.org/2004/02/skos/core#prefLabel": [
+                {
+                    "@language": "en",
+                    "@value": "Visual Stimulus Response instructions"
+                }
+            ],
+            "reprolib:terms/inputType": [
+                {
+                    "@type": "http://www.w3.org/2001/XMLSchema#string",
+                    "@value": "markdown-message"
+                }
+            ],
+            "schema:description": [
+                {
+                    "@language": "en",
+                    "@value": "Instructions for the Visual Stimulus Response widget"
+                }
+            ],
+            "schema:question": [
+                {
+                    "@language": "en",
+                    "@value": "## Visual Stimulus Response\r\n\r\nThe following page is an example of the Visual Stimulus Response widget. This complex widget shows the user a certain number of trials. In each trial the user is presented with a visual stimulus in the center of the screen. The user must respond to the stimuli by pressing a button at the bottom of the screen.\r\n\r\nThis widget is highly configurable. You can configure the sampling method and sampling size, whether to show the user feedback, and much more.\r\n\r\nThe following page contains a little Jeopardy! quiz."
+                }
+            ],
+            "schema:schemaVersion": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/vsr-instructions",
+            "schema:version": [
+                {
+                    "@language": "en",
+                    "@value": "0.0.1"
+                }
+            ],
+            "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/activities/MindLoggerDemo/items/vsr-instructions"
+        }
+    },
+    "protocol": {
+        "@type": [
+            "reprolib:schemas/Protocol"
+        ],
+        "_id": "protocol/5ea7175c86d25a5dbb14ea29",
+        "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/protocols/mindlogger-demo/mindlogger-demo_schema",
+        "schema:url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/protocols/mindlogger-demo/mindlogger-demo_schema",
+        "url": "https://raw.githubusercontent.com/ReproNim/reproschema/master/protocols/mindlogger-demo/mindlogger-demo_schema"
+    }
+}

--- a/app/components/ActivityList/sortActivities.js
+++ b/app/components/ActivityList/sortActivities.js
@@ -68,10 +68,11 @@ export default (activityList, inProgress, schedule) => {
   // const completed = getCompleted(notInProgress).reverse();
 
   return [
-    ...addSectionHeader(addProp('status', 'pastdue', pastdue), 'Past Due'),
+    // ...addSectionHeader(addProp('status', 'pastdue', pastdue), 'Past Due'),
     ...addSectionHeader(addProp('status', 'in-progress', inProgressActivities), 'In Progress'),
-    ...addSectionHeader(addProp('status', 'unscheduled', unscheduled), 'Unscheduled'),
+    //...addSectionHeader(addProp('status', 'unscheduled', unscheduled), 'Unscheduled'),
     // ...addSectionHeader(addProp('status', 'completed', completed), 'Completed'),
-    ...addSectionHeader(addProp('status', 'scheduled', scheduled), 'Scheduled'),
+    // ...addSectionHeader(addProp('status', 'scheduled', scheduled), 'Scheduled'),
+    ...addSectionHeader(addProp('status', 'ready', notInProgress), 'Ready'),
   ];
 };

--- a/app/state/applets/applets.thunks.js
+++ b/app/state/applets/applets.thunks.js
@@ -25,6 +25,7 @@ import {
 } from './applets.actions';
 import { sync } from '../app/app.thunks';
 import { transformApplet } from '../../models/json-ld';
+import demoApplet from '../../applets/demoApplet.json';
 
 export const scheduleAndSetNotifications = () => (dispatch, getState) => {
   const state = getState();
@@ -51,7 +52,9 @@ export const downloadApplets = () => (dispatch, getState) => {
   const auth = authSelector(state);
   const userInfo = userInfoSelector(state);
   dispatch(setDownloadingApplets(true));
-  getApplets(auth.token, userInfo._id).then((applets) => {
+  getApplets(auth.token, userInfo._id).then((appletsResp) => {
+    const applets = appletsResp;
+    applets.unshift(demoApplet);
     if (loggedInSelector(getState())) { // Check that we are still logged in when fetch finishes
       const transformedApplets = applets
         .filter(applet => !R.isEmpty(applet.items))


### PR DESCRIPTION
- Adds ```demoApplet.js```, an expanded jsonld schema for a sample applet
- Modifies ```scheduleAndSetNotification``` thunk to make demo applet available to every user