### PR TITLE
Handle addProperties Key Conditional Logic

### DIFF
--- a/app/models/json-ld.js
+++ b/app/models/json-ld.js
@@ -1,7 +1,8 @@
 import * as R from 'ramda';
 
-const ALLOW = 'reprolib:terms/allow';
 const ABOUT = 'http://schema.org/about';
+const ADD_PROPERTIES = 'reprolib:terms/addProperties';
+const ALLOW = 'reprolib:terms/allow';
 const ALT_LABEL = 'http://www.w3.org/2004/02/skos/core#altLabel';
 const AUDIO_OBJECT = 'http://schema.org/AudioObject';
 const AUTO_ADVANCE = 'reprolib:terms/auto_advance';
@@ -230,9 +231,21 @@ export const activityTransformJson = (activityJson, itemsJson) => {
   const notification = {}; // TO DO
   const info = languageListToObject(activityJson.info); // TO DO
 
-  const isVariableMapExpanded = R.hasPath([VARIABLE_MAP, 0, '@list'], activityJson);
-  const variableMapPath = isVariableMapExpanded ? [VARIABLE_MAP, 0, '@list'] : [VARIABLE_MAP];
-  const variableMapAr = R.pathOr([], variableMapPath, activityJson);
+  const variableMapAr = (() => {
+    if (R.hasPath([VARIABLE_MAP, 0, '@list'], activityJson)) {
+      return R.path([VARIABLE_MAP, 0, '@list'], activityJson);
+    }
+    if (R.hasPath([VARIABLE_MAP], activityJson)) {
+      return R.path([VARIABLE_MAP], activityJson);
+    }
+    if (R.hasPath([ADD_PROPERTIES, 0, '@list'], activityJson)) {
+      return R.path([ADD_PROPERTIES, 0, '@list'], activityJson);
+    }
+    if (R.hasPath([ADD_PROPERTIES], activityJson)) {
+      return R.path([ADD_PROPERTIES], activityJson);
+    }
+    return [];
+  })();
 
   const variableMap = transformVariableMap(variableMapAr);
   const visibility = listToObject(activityJson[VISIBILITY]);


### PR DESCRIPTION
- Modify ```json-ld.js``` parsing logic to handle variable maps defined with the 
 ```reprolib:terms/addProperties``` key
    - Use IIFE to check 4 possible paths for variable map